### PR TITLE
Handle error returned by PebbleDB's NewIter method

### DIFF
--- a/pebble.go
+++ b/pebble.go
@@ -242,7 +242,10 @@ func (db *PebbleDB) Iterator(start, end []byte) (Iterator, error) {
 		LowerBound: start,
 		UpperBound: end,
 	}
-	itr := db.db.NewIter(&o)
+	itr, err := db.db.NewIter(&o)
+    	if err != nil {
+	     return nil, err
+    	}
 	itr.First()
 
 	return newPebbleDBIterator(itr, start, end, false), nil
@@ -258,7 +261,10 @@ func (db *PebbleDB) ReverseIterator(start, end []byte) (Iterator, error) {
 		LowerBound: start,
 		UpperBound: end,
 	}
-	itr := db.db.NewIter(&o)
+	itr, err := db.db.NewIter(&o)
+    	if err != nil {
+        	return nil, err
+    	}
 	itr.Last()
 	return newPebbleDBIterator(itr, start, end, true), nil
 }


### PR DESCRIPTION
This pull request updates the `Iterator` and `ReverseIterator` functions in the PebbleDB integration to handle an additional return value from the `NewIter` method. Previously, `NewIter` was expected to return a single value, the iterator itself. However, a recent update to the underlying Pebble library has modified `NewIter` to return two values: the iterator and an error.

### Changes Made:
- Modified the `Iterator` and `ReverseIterator` functions to capture and check the error returned by `NewIter`.
- If an error is returned when calling `NewIter`, the error is handled appropriately by returning `nil` for the iterator and propagating the error up to the caller.